### PR TITLE
fix: set default value for `CanDirty` to allow health update

### DIFF
--- a/Source/Vehicles/Components/Vehicles/Health/VehicleStatHandler.cs
+++ b/Source/Vehicles/Components/Vehicles/Health/VehicleStatHandler.cs
@@ -67,7 +67,7 @@ public class VehicleStatHandler : IExposable, ITweakFields
         c.props.categories.Min(ctg => ctg.displayPriorityInCategory) :
         9999).ThenBy(c => c.HealthPercent).ToList();
 
-  public bool CanDirty { get; internal set; }
+  public bool CanDirty { get; internal set; } = true;
 
   public bool NeedsRepairs => components.Any(c => c.HealthPercent < 1);
 


### PR DESCRIPTION
After https://github.com/SmashPhil/Vehicle-Framework/commit/7243e9307b160281181a98f5c5de80205f0e1f87, vehicles are not destroyed when body integrity is 0%. This PR should fix it, but I'm not sure if it will break other things.