### PR TITLE
fix: correct angle to direction for north and west

### DIFF
--- a/Source/Vehicles/Components/Vehicles/Health/VehicleStatHandler.cs
+++ b/Source/Vehicles/Components/Vehicles/Health/VehicleStatHandler.cs
@@ -870,22 +870,22 @@ public class VehicleStatHandler : IExposable, ITweakFields
       return Rot4.Invalid;
     }
 
-    if (angle >= 45 && angle <= 135)
+    if (angle > 45 && angle <= 135)
     {
       return Rot4.East;
     }
 
-    if (angle >= 135 && angle <= 225)
+    if (angle > 135 && angle <= 225)
     {
       return Rot4.South;
     }
 
-    if (angle >= 225 && angle <= 335)
+    if (angle > 225 && angle <= 315)
     {
       return Rot4.West;
     }
 
-    if (angle >= 335 || angle <= 45)
+    if (angle > 315 || angle <= 45)
     {
       return Rot4.North;
     }


### PR DESCRIPTION
This appears to be a mistake, a miscalculation of the angle that caused the west to receive more attack than the north.