### PR TITLE
fix: null reference when loading item to vehicle with energy turret

### DIFF
--- a/Source/Vehicles/Turrets/Turret/VehicleTurret.cs
+++ b/Source/Vehicles/Turrets/Turret/VehicleTurret.cs
@@ -1348,6 +1348,11 @@ public partial class VehicleTurret : IExposable, ILoadReferenceable, ITweakField
 
   public bool ContainsAmmoDefOrShell(ThingDef ammoDef)
   {
+    if (def.ammunition is null)
+    {
+      return false;
+    }
+
     ThingDef projectile = null;
     if (ammoDef.projectileWhenLoaded != null)
     {


### PR DESCRIPTION
When loading to a vehicle with a turret that doesn't need ammo (e.g., energy turret), the game throws a null reference error. That causes infinite loading things.