### PR TITLE
Fix overlapping hyperlinks: Modify DrawHyperlinks method

### DIFF
--- a/Source/Vehicles/Utility/VehicleInfoCard.cs
+++ b/Source/Vehicles/Utility/VehicleInfoCard.cs
@@ -358,12 +358,13 @@ namespace Vehicles
 		private static float DrawHyperlinks(Rect rect, VehicleStatDrawEntry statDrawEntry, float textHeight)
 		{
 			float heightTaken = 0;
-			Rect hyperlinkRect = new Rect(rect.x, rect.y + textHeight, rect.width, textHeight);
+			Rect hyperlinkRect = new Rect(rect.x, rect.y + textHeight, rect.width, Text.LineHeight);
 			Color color = GUI.color;
 			GUI.color = Widgets.NormalOptionColor;
 			foreach (Dialog_InfoCard.Hyperlink hyperlink in statDrawEntry.GetHyperlinks(vehicle))
 			{
-				float hyperlinkHeight = Text.CalcHeight(hyperlink.Label, hyperlinkRect.width);
+				float hyperlinkHeight = Mathf.Max(Text.LineHeight, Text.CalcHeight(hyperlink.Label, hyperlinkRect.width));
+				hyperlinkRect.height = hyperlinkHeight;
 				Widgets.HyperlinkWithIcon(hyperlinkRect, hyperlink, "ViewHyperlink".Translate(hyperlink.Label), 2f, 6f, null, false, null);
 				hyperlinkRect.y += hyperlinkHeight;
 				heightTaken += hyperlinkHeight;


### PR DESCRIPTION
Reported in DS: https://discord.com/channels/588278492655910925/1396139622454661131

## Issue
If vehicle has hyperlinks, then they overlap each other. It is impossible to click on hyperlink in the middle.

## How to reproduce
- Place any vehicle with hyperlinks in their description. Easiest way - use CE mod and vehicle with ammo (https://steamcommunity.com/sharedfiles/filedetails/?id=3410965054).
- Open info panel and description section. Hyperlinks will overlap each other.

## Root cause
- Previously displayed text area height (the whole description area) is being used for initial size of Rect for displaying hyperlink.

## Fix
- Initialize Rect with typical 1-line text's height.
- Use the calculated height in foreach block (height is calculated based on hyperlink label).

## Test
Before
<img width="951" height="762" alt="1_Before" src="https://github.com/user-attachments/assets/7f685cdc-40c0-4254-b3aa-5a50bf73e073" />
After
<img width="950" height="760" alt="1_After" src="https://github.com/user-attachments/assets/30d61e0a-2eee-40e6-a09c-e5c079664d5c" />

### DLL Assembly
Not included