### PR TITLE
Update `VehiclePathGrid.cs`.

### DIFF
--- a/Source/Vehicles/Pathing/RegionGrid/VehiclePathGrid.cs
+++ b/Source/Vehicles/Pathing/RegionGrid/VehiclePathGrid.cs
@@ -194,7 +194,7 @@ namespace Vehicles
 				ThingGrid thingGrid = map.thingGrid;
 				lock (thingGrid)
 				{
-					List<Thing> thingList = thingGrid.ThingsListAt(cell);
+					Thing[] thingList = thingGrid.ThingsListAt(cell).ToArray();
 					stringBuilder?.AppendLine("Starting ThingList check.");
 					if (!thingList.NullOrEmpty())
 					{


### PR DESCRIPTION
The value returned by `thingGrid.ThingListAt()` is a raw list that can mutate unexpectedly. Mutation of a list invalidates any enumerators of the list, leading to exceptions. This fixes an issue that frequently happens in my game, presumably it is a soft incompatibility with PUAH, but I don't have hard evidence, just an empirical guess based on a similar problem in other mods what were traced back to it. Regardless of whether it is true, assuming the list doesn't change while it is being iterated over is a bad assumption as it is literally a list of things at a cell, which is dynamic, so making a defensive copy is needed.