### PR TITLE
Fix CE turret firing null reference exceptions

### DIFF
--- a/Source/Vehicles/Turrets/Turret/VehicleTurret_CombatExtended.cs
+++ b/Source/Vehicles/Turrets/Turret/VehicleTurret_CombatExtended.cs
@@ -52,8 +52,8 @@ public partial class VehicleTurret
     float spread = swayAndSpread * 0.16f;
     // recoil should be taken from the def mod extension, this is just an arbitrary default based
     // on the backward recoil for the turret animation, and not related to CE's vertical recoil
-    // accuracy factor.
-    float recoil = def.recoil.distanceTotal;
+    // accuracy factor, defauling to 0 if turret has no recoil
+    float recoil = (def.recoil != null) ? def.recoil.distanceTotal : 0.0f;
     float shotHeight = 1f;
 
     CETurretDataDefModExtension turretData =

--- a/Source/Vehicles/Turrets/Turret/VehicleTurret_CombatExtended.cs
+++ b/Source/Vehicles/Turrets/Turret/VehicleTurret_CombatExtended.cs
@@ -52,7 +52,7 @@ public partial class VehicleTurret
     float spread = swayAndSpread * 0.16f;
     // recoil should be taken from the def mod extension, this is just an arbitrary default based
     // on the backward recoil for the turret animation, and not related to CE's vertical recoil
-    // accuracy factor, defauling to 0 if turret has no recoil
+    // accuracy factor, defaulting to 0 if turret has no recoil
     float recoil = (def.recoil != null) ? def.recoil.distanceTotal : 0.0f;
     float shotHeight = 1f;
 


### PR DESCRIPTION
A very small fix for the null reference exception causing some turrets to not fire when CE is loaded.

This fixes all of the vehicles that were encountering this problem (in my modlist), including ones from RimThunder, GTEK and VVE.

Occurs when the vehicle turret defs do not have recoil properties set in the VehicleTurretDef directly (most turrets do not recoil, the guns themself recoil).
Code correctly gathers recoil information later from the CETurretDataDefModExtension, but prior to this, asks for a field which can be null.

Example of error stack trace before fix is applied:
```Exception thrown while shooting turret RT_Apoch57_Turret_VehicleTurretGroup_1094691. Removing from queue to resolve issue temporarily.
Exception=System.NullReferenceException: Object reference not set to an instance of an object [Ref 45CF099A]
at Vehicles.VehicleTurret.FireTurretCE (Verse.ThingDef projectileDef, UnityEngine.Vector3 launchPos) [0x00058] in <73eb317f21524a81ad0b2855b0fc9b71>:0
at Vehicles.VehicleTurret.FireTurret () [0x003e0] in <73eb317f21524a81ad0b2855b0fc9b71>:0
    - TRANSPILER OELS.VehicleMapFramework: IEnumerable1 VehicleMapFramework.VMF_HarmonyPatches.Patch_VehicleTurret_FireTurret:Transpiler(IEnumerable1 instructions)
    - PREFIX OskarPotocki.VEF: Void VEF.Weapons.VanillaExpandedFramework_VehicleFramework_Turret_Patch:Prefix(Object __instance)
    - POSTFIX OskarPotocki.VEF: Void VEF.Weapons.VanillaExpandedFramework_VehicleFramework_Turret_Patch:Postfix()
    at Vehicles.CompVehicleTurrets.ResolveTurretQueue () [0x0009c] in <73eb317f21524a81ad0b2855b0fc9b71>:0
    UnityEngine.StackTraceUtility:ExtractStackTrace () (wrapper dynamic-method)
    MonoMod.Utils.DynamicMethodDefinition:Verse.Log.Error_Patch4 (string)
    Vehicles.CompVehicleTurrets:ResolveTurretQueue ()
    Vehicles.CompVehicleTurrets:CompTick ()
    Vehicles.VehiclePawn:TickAllComps ()
    Vehicles.VehiclePawn:Tick ()
    Verse.Thing:DoTick () (wrapper dynamic-method) MonoMod.Utils.DynamicMethodDefinition:Verse.TickList.Tick_Patch3 (Verse.TickList) (wrapper dynamic-method)
    MonoMod.Utils.DynamicMethodDefinition:Verse.TickManager.DoSingleTick_Patch6 (Verse.TickManager) (wrapper dynamic-method)
    MonoMod.Utils.DynamicMethodDefinition:Verse.TickManager.TickManagerUpdate_Patch1 (Verse.TickManager) (wrapper dynamic-method)
    MonoMod.Utils.DynamicMethodDefinition:Verse.Game.UpdatePlay_Patch3 (Verse.Game) (wrapper dynamic-method)
    MonoMod.Utils.DynamicMethodDefinition:Verse.Root_Play.Update_Patch1 (Verse.Root_Play)
```