### PR TITLE
Fixed to respect the tradeability of def within HandlesThingDef (like StockGenerator_Animals).

### DIFF
--- a/Source/Vehicles/CustomFeatures/Spawner/StockGenerator_Vehicles.cs
+++ b/Source/Vehicles/CustomFeatures/Spawner/StockGenerator_Vehicles.cs
@@ -42,6 +42,8 @@ public class StockGenerator_Vehicles : StockGenerator
 			return false;
 		if (!excludedDefs.NullOrEmpty() && excludedDefs.Contains(vehicleDef))
 			return false;
+		if (thingDef.tradeability == Tradeability.None)
+			return false;
 
 		return (vehicleDef.vehicleCategory & category) == category;
 	}


### PR DESCRIPTION
https://gist.github.com/HugsLibRecordKeeper/c7b6c907fab340a61fd7265e9738f6a9
If the tradeability check is not performed within HandlesThingDef, an error will be thrown, so add the check.