### PR TITLE
Fixed patch operations to respect feature flags.

### DIFF
--- a/1.6/Patches/Raiders/Paratroopers.xml
+++ b/1.6/Patches/Raiders/Paratroopers.xml
@@ -1,10 +1,14 @@
 <?xml version="1.0" encoding="utf-8" ?>
 
 <Patch>
-	<Operation FeatureFlag = "Paratroopers" Class = "PatchOperationAdd">
+	<Operation Class = "PatchOperationConditional">
+		<success>Always</success>
 		<xpath>Defs/RaidStrategyDef[defName = "ImmediateAttack" or defName = "ImmediateAttackSmart"]/arriveModes</xpath>
-		<value>
-			<li>ParatrooperDrop</li>
-		</value>
+		<match FeatureFlag = "Paratroopers" Class = "PatchOperationAdd">
+			<xpath>Defs/RaidStrategyDef[defName = "ImmediateAttack" or defName = "ImmediateAttackSmart"]/arriveModes</xpath>
+			<value>
+				<li>ParatrooperDrop</li>
+			</value>
+		</match>
 	</Operation>
 </Patch>

--- a/1.6/Patches/Traders/VehicleTraderStock.xml
+++ b/1.6/Patches/Traders/VehicleTraderStock.xml
@@ -1,13 +1,17 @@
 <?xml version="1.0" encoding="utf-8" ?>
 
 <Patch>
-	<Operation FeatureFlag = "TradeableVehicles" Class = "PatchOperationAdd">
+	<Operation Class = "PatchOperationConditional">
+		<success>Always</success>
 		<xpath>Defs/TraderKindDef[defName="Base_Outlander_Standard"]/stockGenerators</xpath>
-		<value>
-			<li Class="Vehicles.StockGenerator_Vehicles">
-        <category>Combat</category>
-        <countRange>1~2</countRange>
-      </li>
-		</value>
+		<match FeatureFlag = "TradeableVehicles" Class = "PatchOperationAdd">
+			<xpath>Defs/TraderKindDef[defName="Base_Outlander_Standard"]/stockGenerators</xpath>
+			<value>
+				<li Class="Vehicles.StockGenerator_Vehicles">
+					<category>Combat</category>
+					<countRange>1~2</countRange>
+				</li>
+			</value>
+		</match>
 	</Operation>
 </Patch>


### PR DESCRIPTION
Operations written in the `<patch>` block do not pass through XmlToObjectUtils.DoFieldSearch(), so preprocessing using custom attributes is not performed.
So, I changed the way the patch is written to make the attributes process correctly.
Confirmed that enable/disable toggles correctly depending on the build.