### PR TITLE
Fix disabled reload gizmo when out of ammo

### DIFF
--- a/Source/Vehicles/Gizmo/Command_CooldownAction.cs
+++ b/Source/Vehicles/Gizmo/Command_CooldownAction.cs
@@ -172,7 +172,6 @@ public class Command_CooldownAction : Command_Turret
 		Rect subIconRect = new(gizmoRect.xMax - SubIconSize, gizmoRect.y, SubIconSize, SubIconSize);
 		if ((turret.loadedAmmo is null || turret.shellCount <= 0) && turret.def.ammunition != null)
 		{
-			Disable("VF_NoAmmoLoadedTurret".Translate());
 			ammoLoaded = false;
 		}
 		else if (turret.ProjectileDef is { projectile.flyOverhead: true } &&


### PR DESCRIPTION
Fixes inability to use the reload subgizmo to reload the turret when there is no ammo loaded

Breaks display of "disabled: out of ammo" message in tooltip.

TODO: Duplicate the vanilla gizmo disabled functionality in subgizmos?