### PR TITLE
Draw offset fix for vehicles and overlays when diagonal rendering

### DIFF
--- a/Source/Vehicles/Graphics/GraphicClasses/Vehicle/Graphic_Rgb.cs
+++ b/Source/Vehicles/Graphics/GraphicClasses/Vehicle/Graphic_Rgb.cs
@@ -171,6 +171,37 @@ public class Graphic_Rgb : Graphic
     return materials[rot.AsInt];
   }
 
+  public virtual Vector3 DrawOffset(Rot8 rot)
+  {
+    if (!rot.IsDiagonal)
+    {
+      return base.DrawOffset(rot);
+    }
+    if (EastDiagonalRotated)
+    {
+      if (rot == Rot8.NorthEast)
+      {
+        return base.DrawOffset(Rot4.North);
+      }
+      if (rot == Rot8.SouthEast)
+      {
+        return base.DrawOffset(Rot4.South);
+      }
+    }
+    if (WestDiagonalRotated)
+    {
+      if (rot == Rot8.NorthWest)
+      {
+        return base.DrawOffset(Rot4.North);
+      }
+      if (rot == Rot8.SouthWest)
+      {
+        return base.DrawOffset(Rot4.South);
+      }
+    }
+    return base.DrawOffset(rot);
+  }
+
   public override void Init(GraphicRequest req)
   {
     masks = new Texture2D[MatCount];
@@ -519,7 +550,7 @@ public class Graphic_Rgb : Graphic
         if (EastDiagonalRotated)
         {
           rotation *= -1;
-          rotAngle += Rot8.East.AsAngle;
+          rotAngle *= -1;
         }
       break;
       case 6:
@@ -527,7 +558,7 @@ public class Graphic_Rgb : Graphic
         if (WestDiagonalRotated)
         {
           rotation *= -1;
-          rotAngle += Rot8.West.AsAngle;
+          rotAngle *= -1;
         }
       break;
     }

--- a/Source/Vehicles/Graphics/GraphicClasses/Vehicle/Graphic_Rgb.cs
+++ b/Source/Vehicles/Graphics/GraphicClasses/Vehicle/Graphic_Rgb.cs
@@ -171,7 +171,7 @@ public class Graphic_Rgb : Graphic
     return materials[rot.AsInt];
   }
 
-  public virtual Vector3 DrawOffset(Rot8 rot)
+  public virtual Vector3 DrawOffsetFull(Rot8 rot)
   {
     if (!rot.IsDiagonal)
     {
@@ -514,7 +514,7 @@ public class Graphic_Rgb : Graphic
     {
       position.y = altLayerSpawned.AltitudeFor();
     }
-    Vector3 drawOffset = DrawOffset(transformData.orientation);
+    Vector3 drawOffset = DrawOffsetFull(transformData.orientation);
     drawOffset = Quaternion.AngleAxis(rotAngle, Vector3.up) * drawOffset;
     position += drawOffset;
     render.position = position;

--- a/Source/Vehicles/Graphics/GraphicClasses/Vehicle/Graphic_Rgb.cs
+++ b/Source/Vehicles/Graphics/GraphicClasses/Vehicle/Graphic_Rgb.cs
@@ -564,6 +564,25 @@ public class Graphic_Rgb : Graphic
     }
   }
 
+  // Override for rendering ghosts. Just applied extraRotation to drawOffset
+  public override void DrawWorker(Vector3 loc, Rot4 rot, ThingDef thingDef, Thing thing, float extraRotation)
+  {
+    Mesh mesh = MeshAt(rot);
+    Quaternion quat = QuatFromRot(rot);
+    if (extraRotation != 0f)
+    {
+      quat *= Quaternion.Euler(Vector3.up * extraRotation);
+    }
+    if (data is { addTopAltitudeBias: true })
+    {
+      quat *= Quaternion.Euler(Vector3.left * 2f);
+    }
+    loc += DrawOffset(rot).RotatedBy(extraRotation);
+    Material mat = MatAt(rot, thing);
+    DrawMeshInt(mesh, loc, quat, mat);
+    ShadowGraphic?.DrawWorker(loc, rot, thingDef, thing, extraRotation);
+  }
+
   public override string ToString()
   {
     return

--- a/Source/Vehicles/Graphics/VehicleGhostUtility.cs
+++ b/Source/Vehicles/Graphics/VehicleGhostUtility.cs
@@ -56,8 +56,7 @@ public static class VehicleGhostUtility
   // public static void DrawGhostOverlays(IntVec3 center, Rot8 rot, VehicleDef vehicleDef,
   //   Graphic baseGraphic, Color ghostCol, AltitudeLayer drawAltitude, Thing thing = null)
   // {
-  //   _ = baseGraphic;
-  //   DrawGhostOverlays(center, rot, vehicleDef, ghostCol, drawAltitude, thing);
+  //   DrawGhostOverlays(center, rot, vehicleDef, baseGraphic, ghostCol, drawAltitude, thing, null);
   // }
   
   public static void DrawGhostOverlays(IntVec3 center, Rot8 rot, VehicleDef vehicleDef,

--- a/Source/Vehicles/Graphics/VehicleGhostUtility.cs
+++ b/Source/Vehicles/Graphics/VehicleGhostUtility.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using RimWorld;
 using SmashTools;
 using UnityEngine;
-using Vehicles.Rendering;
 using Verse;
 
 namespace Vehicles;
@@ -49,20 +48,40 @@ public static class VehicleGhostUtility
     graphic.DrawFromDef(loc, baseRot, vehicleDef, baseAngle);
 
     DrawGhostOverlays(center, rot, vehicleDef, baseGraphic, ghostCol, drawAltitude,
-      thing: vehicle);
+      thing: vehicle, baseRot: baseRot, baseAngle: baseAngle);
   }
 
+  // Public method signatures have been changed. Please add a stub if necessary
+  // Vehicle Map Framework patches will be affected, so I'll make it that absorbs the changes if the PR is accepted
+  // public static void DrawGhostOverlays(IntVec3 center, Rot8 rot, VehicleDef vehicleDef,
+  //   Graphic baseGraphic, Color ghostCol, AltitudeLayer drawAltitude, Thing thing = null)
+  // {
+  //   _ = baseGraphic;
+  //   DrawGhostOverlays(center, rot, vehicleDef, ghostCol, drawAltitude, thing);
+  // }
+  
   public static void DrawGhostOverlays(IntVec3 center, Rot8 rot, VehicleDef vehicleDef,
-    Graphic baseGraphic, Color ghostCol, AltitudeLayer drawAltitude, Thing thing = null)
+    Graphic baseGraphic, Color ghostCol, AltitudeLayer drawAltitude, Thing thing = null, Rot8? baseRot = null, float baseAngle = 0f)
   {
-    Vector3 loc = GenThing.TrueCenter(center, rot, vehicleDef.Size, drawAltitude.AltitudeFor());
+    Rot4 drawRot = baseRot ?? rot;
+    Vector3 loc = GenThing.TrueCenter(center, drawRot, vehicleDef.Size, drawAltitude.AltitudeFor());
+    if (baseAngle != 0f)
+    {
+      Vector3 offset = baseGraphic.DrawOffset(drawRot).RotatedBy(baseAngle);
+      if ((Rot4)rot == Rot4.East)
+      {
+        offset *= -1f;
+      }
+      loc += offset;
+    }
     foreach ((Graphic graphic, float rotation) in vehicleDef.GhostGraphicOverlaysFor(ghostCol))
     {
-      graphic.DrawWorker(loc + baseGraphic.DrawOffsetFull(rot), rot, vehicleDef, thing, rotation);
+      float extraRotation = baseAngle + rotation;
+      graphic.DrawWorker(loc, drawRot, vehicleDef, thing, extraRotation);
     }
     if (vehicleDef.GetSortedCompProperties<CompProperties_VehicleTurrets>() is not null)
     {
-      vehicleDef.DrawGhostTurretTextures(loc, rot, ghostCol);
+      vehicleDef.DrawGhostTurretTextures(loc, drawRot, ghostCol);
     }
   }
 


### PR DESCRIPTION
https://gist.github.com/HugsLibRecordKeeper/f253bc900b3b3720df98ec26a013144b
(No errors)

Draw offsets are not currently applied correctly.
Prepared a Mosquito that can be moved for testing and a BangBus with a draw offset set. ((0, 0, 0.5) for north / south)
<img width="713" height="756" alt="image" src="https://github.com/user-attachments/assets/4dc1cdd8-4f42-4adc-9102-531dec4e2127" />
<img width="311" height="254" alt="image" src="https://github.com/user-attachments/assets/cc132ba8-066f-4565-8c99-3be54c1afd26" />

I think since the north/south textures are used when diagonal rendering (unless specifically drawn otherwise), I believe its draw offsets should be applied. Changes were made to apply the vertical direction offsets using the same logic as MeshAtFull. This change also resolves the overlay misalignment.
<img width="705" height="710" alt="image" src="https://github.com/user-attachments/assets/08c22fb9-fef5-43b7-a4b6-ceff68eef356" />

Applying transform data is also fine.
<img width="553" height="418" alt="image" src="https://github.com/user-attachments/assets/46d5a0cf-9fb0-4894-8946-de48d0c33c0e" />

The second commit is optional as it involves overriding DrawWorker and changing the signature, but it resolves the overlay misalignment in ghost graphics.
<img width="375" height="293" alt="image" src="https://github.com/user-attachments/assets/10e73a43-3740-44b6-9d7f-054fdb67efac" />