### PR TITLE
TryAssignToSickPawn in Patch_CaravanHandling.RecalculateUsedBedsInVehicleCaravan is not passing the instance to FastInvokeHandler.

### DIFF
--- a/Source/Vehicles/Harmony/Patches/Patch_CaravanHandling.cs
+++ b/Source/Vehicles/Harmony/Patches/Patch_CaravanHandling.cs
@@ -1106,7 +1106,7 @@ internal class Patch_CaravanHandling : IPatchCategory
 					if (caravan.vehiclePather.MovingNow && !pawn.CarriedByCaravan())
 						return;
 
-					Building_Bed andRemoveFirstAvailableBedFor2 = (Building_Bed)GetAndRemoveFirstAvailableBedFor(pawn, usableBeds);
+					Building_Bed andRemoveFirstAvailableBedFor2 = (Building_Bed)GetAndRemoveFirstAvailableBedFor(instance, pawn, usableBeds);
 					if (andRemoveFirstAvailableBedFor2 != null)
 					{
 						usedBeds.Add(pawn, andRemoveFirstAvailableBedFor2);


### PR DESCRIPTION
[Player.log](https://github.com/user-attachments/files/24266888/Player.log)
This is a log submitted by a user. Errors related to VF have occurred.
```
System.IndexOutOfRangeException: Index was outside the bounds of the array.
[Ref 8246277D]
(wrapper dynamic-method) MonoMod.Utils.DynamicMethodDefinition.FastInvoke_GetAndRemoveFirstAvailableBedFor_indirect(object,object[])
  at Vehicles.Patch_CaravanHandling.<RecalculateUsedBedsInVehicleCaravan>g__TryAssignToSickPawn|49_3 (Verse.Pawn pawn, Vehicles.World.VehicleCaravan caravan, RimWorld.Planet.Caravan_BedsTracker instance, System.Collections.Generic.Dictionary`2[TKey,TValue] usedBeds, System.Collections.Generic.List`1[T] usableBeds) [0x00033] in C:\Program Files (x86)\Steam\steamapps\common\RimWorld\Mods\Vehicle-Framework\Source\Vehicles\Harmony\Patches\Patch_CaravanHandling.cs:1109 
  at Vehicles.Patch_CaravanHandling.RecalculateUsedBedsInVehicleCaravan (RimWorld.Planet.Caravan_BedsTracker __instance, System.Collections.Generic.Dictionary`2[TKey,TValue] ___usedBeds) [0x0015c] in C:\Program Files (x86)\Steam\steamapps\common\RimWorld\Mods\Vehicle-Framework\Source\Vehicles\Harmony\Patches\Patch_CaravanHandling.cs:1091 
  at RimWorld.Planet.Caravan_BedsTracker.RecalculateUsedBeds () [0x0000a] in <88df42e0e943404ba42043aebd37585c>:0 
    - PREFIX SmashPhil.VehicleFramework: Boolean Vehicles.Patch_CaravanHandling:RecalculateUsedBedsInVehicleCaravan(Caravan_BedsTracker __instance, Dictionary`2 ___usedBeds)
  at RimWorld.Planet.Caravan_BedsTracker.BedsTrackerTickInterval (System.Int32 delta) [0x00000] in <88df42e0e943404ba42043aebd37585c>:0 
  at RimWorld.Planet.Caravan.TickInterval (System.Int32 delta) [0x0003d] in <88df42e0e943404ba42043aebd37585c>:0 
    - POSTFIX com.inspirationtweaks.patch: Void InspirationTweaks.CaravanTick:Postfix(Caravan __instance, Int32 delta)
    - POSTFIX oskarpotocki.vfe.classical: Void VFEC.WorldComponent_RoadBuilding:PostTick(Caravan __instance)
    - POSTFIX com.yayo.caravanVisual: Void caravanVisual.HarmonyPatches.Caravan_TickInterval:Postfix(Caravan __instance, Int32 delta)
  at RimWorld.Planet.WorldObject.DoTick () [0x00066] in <88df42e0e943404ba42043aebd37585c>:0 
  at RimWorld.Planet.WorldObjectsHolder.WorldObjectsHolderTick () [0x00029] in <88df42e0e943404ba42043aebd37585c>:0 
  at RimWorld.Planet.World.WorldTick () [0x00016] in <88df42e0e943404ba42043aebd37585c>:0 
  at Verse.TickManager.DoSingleTick () [0x00111] in <88df42e0e943404ba42043aebd37585c>:0 
    - PREFIX OskarPotocki.VEF: Void VEF.Maps.VanillaExpandedFramework_DoSingleTick_Patch:Prefix(Stopwatch& __state)
    - PREFIX LightsOut: Void LightsOut.Patches.Power.PerformPendingShutoff:Prefix()
    - PREFIX YourName.PauseOtherSettlementsSimulation: Void PauseOtherSettlementsSimulation.TickManager_DoSingleTick_CachePatch:Prefix()
    - PREFIX net.pardeike.rimworld.mods.achtung: Void AchtungMod.TickManager_DoSingleTick_Patch:Prefix()
    - POSTFIX Owlchemist.MidSaverSaver: Void MidsaverSaver.CheckWorldObjects:Postfix()
    - POSTFIX OskarPotocki.VEF: Void VEF.Maps.VanillaExpandedFramework_DoSingleTick_Patch:Postfix(Stopwatch __state)
    - POSTFIX jpt.speakup: Void SpeakUp.TickManager_DoSingleTick:Postfix()
    - POSTFIX Owlchemist.ScatteredFlames: Void ScatteredFlames.Patch_TickManager_DoSingleTick:Postfix()
    - POSTFIX Helixien.ReGrowthCore: Void ReGrowthCore.Patch_TickManager_DoSingleTick:Postfix()
Unloading 304 unused Assets to reduce memory usage. Loaded Objects now: 175296.
Total: 20280.764375 ms (FindLiveObjects: 76.991625 ms CreateObjectMapping: 5.734625 ms MarkObjects: 20190.304791 ms  DeleteObjects: 7.730250 ms)
```
Simply forgot to pass the instance, so I fixed it.
