### PR TITLE
Rotate the draw offset of the PawnRenderer using TransformData.rotation.

### DIFF
--- a/Source/Vehicles/Components/Vehicles/VehicleRoleHandler.cs
+++ b/Source/Vehicles/Components/Vehicles/VehicleRoleHandler.cs
@@ -116,7 +116,7 @@ namespace Vehicles
 			foreach (Pawn pawn in thingOwner)
 			{
 				Rot4 rotOverride = role.PawnRenderer.RotFor(transformData.orientation);
-				Vector3 offset = role.PawnRenderer.DrawOffsetFor(transformData.orientation);
+				Vector3 offset = role.PawnRenderer.DrawOffsetFor(transformData.orientation).RotatedBy(transformData.rotation);
 				pawn.Drawer.renderer.DynamicDrawPhaseAt(phase, transformData.position + offset,
 					rotOverride: rotOverride, neverAimWeapon: true);
 			}


### PR DESCRIPTION
This is a screenshot provided by a user.
![Screenshot_2025-12-16_at_11 32 12](https://github.com/user-attachments/assets/e7ca5a7c-e521-49c7-8eff-314aa87d434b)
The vehicle is facing north and rotated using Transform.rotation, and pawns are rendered using the VF functionality (PawnRenderer).
Modified to rotate the drawing offset using this additional rotation.