### PR TITLE
Fix changing ammo type for vehicle turrets

### DIFF
--- a/Source/Vehicles/Turrets/Turret/VehicleTurret.cs
+++ b/Source/Vehicles/Turrets/Turret/VehicleTurret.cs
@@ -1146,6 +1146,8 @@ public partial class VehicleTurret : IExposable, ILoadReferenceable, ITweakField
 			if (ammoDef != savedAmmoType)
 				TryClearChamber();
 
+			savedAmmoType = ammoDef;
+
 			int countToRefill = def.magazineCapacity - shellCount;
 			int countToTake = Mathf.CeilToInt(countToRefill * def.chargePerAmmoCount);
 			int countRefilled = 0;


### PR DESCRIPTION
For vehicle turrets that support multiple ammo types, ReloadInternal() tries to remove already loaded ammo if the new ammo to load is of different type than `savedAmmoType`. This doesn't work since f7b9a52398ae84d1610a5797132746d4d976e0df because `savedAmmoType` is never written. So, assign it on reload.