### PR TITLE
added support for `CaravanBonusSpeedFactor` from equipment

### DIFF
--- a/Source/Vehicles/World/Caravan/VehicleCaravanTicksPerMoveUtility.cs
+++ b/Source/Vehicles/World/Caravan/VehicleCaravanTicksPerMoveUtility.cs
@@ -62,7 +62,22 @@ public static class VehicleCaravanTicksPerMoveUtility
 					float worldSpeedMultiplier = vehicle.WorldSpeedMultiplier;
 					float moveSpeed = vehicle.GetStatValue(VehicleStatDefOf.MoveSpeed) *
 						worldSpeedMultiplier / 60;
-					if (moveSpeed > 0)
+
+                    // Highest equipment bonus among everyone inside -> stacking effects could probably easily break the game
+                    float maxEquipmentBonus = 1f;
+
+                    foreach (Pawn occupant in vehicle.AllPawnsAboard)
+                    {
+                        float pawnStat = occupant.GetStatValue(StatDefOf.CaravanBonusSpeedFactor);
+                        if (pawnStat > maxEquipmentBonus)
+                        {
+                            maxEquipmentBonus = pawnStat;
+                        }
+                    }
+
+                    moveSpeed *= maxEquipmentBonus;
+
+                    if (moveSpeed > 0)
 					{
 						int ticksPerTile = TicksFromMoveSpeed(moveSpeed);
 						MoveSpeedTicks.Add(ticksPerTile);


### PR DESCRIPTION
This is a relatively low-effort pull request, as I don't actually know much about RimWorld modding or the Vehicle Framework codebase. I wanted to address an issue where equipment-based caravan speed bonuses (specifically from "Bundle of Trinkets" mod) are ignored once a pawn enters a vehicle. Please feel free to close this and implement a "proper" version if this doesn't meet the framework's standards.

Tested using the "Nautical Compass" from _Bundle of Trinkets_ on a _Longship_ from _Alpha Vehicles - Age of Sail_. The bonus applied correctly once the pawn boarded.

Known Issue: Because this uses `AllPawnsAboard`, the speed bonus only appears once the pawns are physically inside the vehicle. It does not currently reflect the bonus during the initial "Form Caravan" planning stage before the pawns have boarded (if the pawn isn't already inside). Maybe you know an immediate fix for that.

Thanks for the incredible work on the framework!

(I also used the `release/1.6` as a base because I couldn't make anything compile on the `develop` branch - don't know if that changes anything)