### PR TITLE
Fixed an issue where RaiderPermissions were being saved in Scribe_Values

### DIFF
--- a/Source/Vehicles/AI/Lords/Raids/LordJob_ArmoredAssault.cs
+++ b/Source/Vehicles/AI/Lords/Raids/LordJob_ArmoredAssault.cs
@@ -154,7 +154,7 @@ public class LordJob_ArmoredAssault : LordJob_VehicleNPC
   public override void ExposeData()
   {
     Scribe_References.Look(ref assaulterFaction, nameof(assaulterFaction));
-    Scribe_Values.Look(ref permission, nameof(permission), RaiderPermissions.All);
+    Scribe_Deep.Look(ref permission, nameof(permission));
     Scribe_Values.Look(ref behavior, nameof(behavior), RaiderBehavior.None);
   }
 


### PR DESCRIPTION
https://gist.github.com/HugsLibRecordKeeper/13d7bfc87ae5680e33e64a7f68dcb174
The following error was observed during the development of a derivative mod.
> Using Scribe_Values with a IExposable reference permission. Use Scribe_References or Scribe_Deep instead.
UnityEngine.StackTraceUtility:ExtractStackTrace ()
(wrapper dynamic-method) MonoMod.Utils.DynamicMethodDefinition:Verse.Log.Error_Patch2 (string)
Verse.Scribe_Values:Look<Vehicles.LordJob_ArmoredAssault/RaiderPermissions> (Vehicles.LordJob_ArmoredAssault/RaiderPermissions&,string,Vehicles.LordJob_ArmoredAssault/RaiderPermissions,bool)
Vehicles.LordJob_ArmoredAssault:ExposeData () (at E:/Program Files (x86)/Steam/steamapps/common/RimWorld/Mods/VehicleFramework/Source/Vehicles/AI/Lords/Raids/LordJob_ArmoredAssault.cs:157)
Verse.Scribe_Deep:Look<Verse.AI.Group.LordJob> (Verse.AI.Group.LordJob&,bool,string,object[])
Verse.Scribe_Deep:Look<Verse.AI.Group.LordJob> (Verse.AI.Group.LordJob&,string,object[])
Verse.AI.Group.Lord:ExposeData ()
Verse.Scribe_Deep:Look<Verse.AI.Group.Lord> (Verse.AI.Group.Lord&,bool,string,object[])
Verse.Scribe_Collections:Look<Verse.AI.Group.Lord> (System.Collections.Generic.List`1<Verse.AI.Group.Lord>&,bool,string,Verse.LookMode,object[])
Verse.Scribe_Collections:Look<Verse.AI.Group.Lord> (System.Collections.Generic.List`1<Verse.AI.Group.Lord>&,string,bool,Verse.LookMode,object[])
Verse.Scribe_Collections:Look<Verse.AI.Group.Lord> (System.Collections.Generic.List`1<Verse.AI.Group.Lord>&,string,Verse.LookMode,object[])
Verse.AI.Group.LordManager:ExposeData ()
Verse.Scribe_Deep:Look<Verse.AI.Group.LordManager> (Verse.AI.Group.LordManager&,bool,string,object[])
Verse.Scribe_Deep:Look<Verse.AI.Group.LordManager> (Verse.AI.Group.LordManager&,string,object[])
Verse.Map:ExposeComponents ()
(wrapper dynamic-method) MonoMod.Utils.DynamicMethodDefinition:Verse.Map.ExposeData_Patch1 (Verse.Map)
Verse.Scribe_Deep:Look<Verse.Map> (Verse.Map&,bool,string,object[])
Verse.Scribe_Collections:Look<Verse.Map> (System.Collections.Generic.List`1<Verse.Map>&,bool,string,Verse.LookMode,object[])
Verse.Scribe_Collections:Look<Verse.Map> (System.Collections.Generic.List`1<Verse.Map>&,string,bool,Verse.LookMode,object[])
Verse.Scribe_Collections:Look<Verse.Map> (System.Collections.Generic.List`1<Verse.Map>&,string,Verse.LookMode,object[])
Verse.Game:ExposeData ()
Verse.Scribe_Deep:Look<Verse.Game> (Verse.Game&,bool,string,object[])
Verse.Scribe_Deep:Look<Verse.Game> (Verse.Game&,string,object[])
Verse.GameDataSaveLoader/<>c:<SaveGame>b__28_0 ()
Verse.SafeSaver:DoSave (string,string,System.Action)
Verse.SafeSaver:Save (string,string,System.Action,bool)
Verse.GameDataSaveLoader:SaveGame (string)
RimWorld.Dialog_SaveFileList_Save/<>c__DisplayClass3_0:<DoFileInteraction>b__0 ()
Verse.LongEventHandler:UpdateCurrentSynchronousEvent (bool&)
Verse.LongEventHandler:LongEventsUpdate (bool&)
Verse.Root:Update ()
Verse.Root_Play:Update ()

Changed to save RaiderPermission using Scribe_Deep.