### PR TITLE
Fixed collection modified error when vehicle is killed on deep water

### DIFF
--- a/Source/Vehicles/Components/Vehicles/VehiclePawn/VehiclePawn_Health.cs
+++ b/Source/Vehicles/Components/Vehicles/VehiclePawn/VehiclePawn_Health.cs
@@ -331,8 +331,9 @@ public partial class VehiclePawn
 			{
 				StringBuilder downWithShipString = new();
 				bool pawnsLostAtSea = false;
-				foreach (Pawn pawn in AllPawnsAboard)
+				for (int i = AllPawnsAboard.Count - 1; i >= 0; i--)
 				{
+					Pawn pawn = AllPawnsAboard[i];
 					if (HealthHelper.AttemptToDrown(pawn))
 					{
 						pawnsLostAtSea = true;


### PR DESCRIPTION
https://gist.github.com/HugsLibRecordKeeper/60809b5b067f1901909eabdbb0b8f623
When a boat carrying passengers is killed in deep water, the following error is observed.
>Root level exception in OnGUI(): System.InvalidOperationException: Collection was modified; enumeration operation may not execute.
[Ref E63D2F00]
 [0x00000] in <51fded79cd284d4d911c5949aff4cb21>:0 
  at System.Collections.Generic.List`1+Enumerator[T].MoveNextRare () [0x00013] in <51fded79cd284d4d911c5949aff4cb21>:0 
  at System.Collections.Generic.List`1+Enumerator[T].MoveNext () [0x0004a] in <51fded79cd284d4d911c5949aff4cb21>:0 
  at Vehicles.VehiclePawn.Kill (System.Nullable`1[T] dinfo, Verse.DestroyMode destroyMode, System.Boolean spawnWreckage) [0x00177] in E:\Program Files (x86)\Steam\steamapps\common\RimWorld\Mods\VehicleFramework\Source\Vehicles\Components\Vehicles\VehiclePawn\VehiclePawn_Health.cs:334 
  at Vehicles.VehicleComponent.TakeDamage (Vehicles.VehiclePawn _, Verse.DamageInfo& dinfo, System.Boolean ignoreArmor) [0x00148] in E:\Program Files (x86)\Steam\steamapps\common\RimWorld\Mods\VehicleFramework\Source\Vehicles\Components\Vehicles\Health\VehicleComponent.cs:131 
  at Vehicles.VehicleStatHandler.ApplyDamageToComponent (Verse.DamageInfo dinfo, Verse.IntVec2 hitCell, System.Text.StringBuilder report) [0x0078a] in E:\Program Files (x86)\Steam\steamapps\common\RimWorld\Mods\VehicleFramework\Source\Vehicles\Components\Vehicles\Health\VehicleStatHandler.cs:697 
  at Vehicles.VehicleStatHandler.ApplyDamage (Verse.DamageInfo dinfo, Verse.IntVec2 hitCell) [0x0001a] in E:\Program Files (x86)\Steam\steamapps\common\RimWorld\Mods\VehicleFramework\Source\Vehicles\Components\Vehicles\Health\VehicleStatHandler.cs:516 
  at Vehicles.VehicleStatHandler.TakeDamage (Verse.DamageInfo dinfo) [0x000af] in E:\Program Files (x86)\Steam\steamapps\common\RimWorld\Mods\VehicleFramework\Source\Vehicles\Components\Vehicles\Health\VehicleStatHandler.cs:503 
  at Vehicles.VehiclePawn.PreApplyDamage (Verse.DamageInfo& dinfo, System.Boolean& absorbed) [0x00000] in E:\Program Files (x86)\Steam\steamapps\common\RimWorld\Mods\VehicleFramework\Source\Vehicles\Components\Vehicles\VehiclePawn\VehiclePawn_Health.cs:154 
  at Verse.Thing.TakeDamage (Verse.DamageInfo dinfo) [0x000d8] in <46372f5dadbf4af8939e608076251180>:0 
    - PREFIX OskarPotocki.VEF: Void VEF.AnimalBehaviours.Patch_TakeDamage:Prefix(Thing __instance, DamageInfo dinfo)
    - POSTFIX OskarPotocki.VEF: Void VEF.Weapons.VanillaExpandedFramework_Thing_TakeDamage_Patch:Postfix(Thing __instance, DamageInfo dinfo)
  at Verse.DebugToolsGeneral.Take10Damage () [0x0004b] in <46372f5dadbf4af8939e608076251180>:0 
  at LudeonTK.DebugTool.DebugToolOnGUI () [0x00018] in <46372f5dadbf4af8939e608076251180>:0 
  at LudeonTK.DebugTools.DebugToolsOnGUI () [0x00007] in <46372f5dadbf4af8939e608076251180>:0 
  at RimWorld.UIRoot_Play.UIRootOnGUI () [0x000c8] in <46372f5dadbf4af8939e608076251180>:0 
  at Verse.Root.OnGUI () [0x00040] in <46372f5dadbf4af8939e608076251180>:0 
UnityEngine.StackTraceUtility:ExtractStackTrace ()
(wrapper dynamic-method) MonoMod.Utils.DynamicMethodDefinition:Verse.Log.Error_Patch1 (string)
Verse.Root:OnGUI ()

I changed the foreach loop to a for loop.