### PR TITLE
Fixed Transform.rotation so it does not invert

### DIFF
--- a/Source/Vehicles/Graphics/GraphicClasses/Vehicle/Graphic_Rgb.cs
+++ b/Source/Vehicles/Graphics/GraphicClasses/Vehicle/Graphic_Rgb.cs
@@ -501,9 +501,11 @@ public class Graphic_Rgb : Graphic
       material = MatAtFull(transformData.orientation)
     };
 
-    float rotAngle = transformData.orientation.AsRotationAngle + transformData.rotation;
+    float rotAngle = transformData.orientation.AsRotationAngle;
     float rotation = rotAngle + extraRotation;
     AdjustAngle(transformData.orientation, ref rotation, ref rotAngle);
+    rotAngle += transformData.rotation;
+    rotation += transformData.rotation;
     Quaternion quaternion = Quaternion.AngleAxis(rotation, Vector3.up);
     if (data is { addTopAltitudeBias: true })
     {


### PR DESCRIPTION
This issue has already been reported on Discord.
https://discord.com/channels/588278492655910925/1441239360027492352

By adding transformData.rotation after reversing the rotation with AdjustAngle, I ensured that the vehicle's Transform.rotation would not be applied in an unintended reversed state.