### PR TITLE
Fixed path recalculation issue caused by inaccurate vehicle hitboxes

### DIFF
--- a/Source/Vehicles/Components/Vehicles/VehiclePathFollower.cs
+++ b/Source/Vehicles/Components/Vehicles/VehiclePathFollower.cs
@@ -583,7 +583,7 @@ public sealed class VehiclePathFollower : IExposable, IDisposable
     // TODO - add snow tracks / depressions
     //if (vehicle.BodySize > 0.9f)
     //{
-    //  vehicle.Map.snowGrid.AddDepth(vehicle.Position, -SnowReductionFromWalking); 
+    //  vehicle.Map.snowGrid.AddDepth(vehicle.Position, -SnowReductionFromWalking);
     //}
 
     PathRequest pathRequest = NeedNewPath();
@@ -985,8 +985,12 @@ public sealed class VehiclePathFollower : IExposable, IDisposable
       }
     }
 
-    IntVec3 previous = IntVec3.Invalid;
     int nodeIndex = LookAheadStartingIndex;
+    if (nodeIndex >= curPath.NodesLeft)
+      return PathRequest.None;
+
+    IntVec3 previous = curPath.Peek(nodeIndex);
+    nodeIndex++;
     while (nodeIndex < LookAheadStartingIndex + MaxCheckAheadNodes &&
            nodeIndex < curPath.NodesLeft)
     {


### PR DESCRIPTION
https://discord.com/channels/588278492655910925/1463067454279520291/1466714312314716203
The collision check for the path at the end of VehiclePathFollower.NeedNewPath causes unintended path recalculations due to inaccuracies in the hitbox.
https://github.com/user-attachments/assets/9b17f7f2-731f-4f5c-b6f8-d8450d8ae9ba

The issue was resolved by calculating vehicle rotation from at least two nodes.
https://github.com/user-attachments/assets/9a67acdf-89e5-4e22-86de-0f8f7c932ace


Ah, the removal of the half-width space ended up in the commit. Sorry.