### PR TITLE
Cache route planner button mouseover tip instead of getting it every update.

### DIFF
--- a/Source/Vehicles/World/Caravan/VehicleRoutePlanner.cs
+++ b/Source/Vehicles/World/Caravan/VehicleRoutePlanner.cs
@@ -41,6 +41,8 @@ public class VehicleRoutePlanner : WorldComponent
 
 	private bool cantRemoveFirstWaypoint;
 
+	private readonly string mouseoverTip = "VF_RoutePlannerButtonTip".Translate();
+
 	public VehicleRoutePlanner(RimWorld.Planet.World world) : base(world)
 	{
 		this.world = world;
@@ -392,7 +394,7 @@ public class VehicleRoutePlanner : WorldComponent
 				SoundDefOf.Tick_High.PlayOneShotOnCamera();
 			}
 		}
-		TooltipHandler.TipRegion(rect, "VF_RoutePlannerButtonTip".Translate());
+		TooltipHandler.TipRegion(rect, mouseoverTip);
 		curBaseY -= RouteButtonDimension + 20f;
 	}
 


### PR DESCRIPTION
Reasoning: With translation active, converting TaggedString to string for use in UI consumes some time, especially for longer strings like mouseover tip.

Starting with simplest solution, get value once and never update it. I can change to more complicated code updating text regularly, but not as often as every update if compatibility with Hot Reload Defs and/or Hot Language Switch is desired.