### PR TITLE
Bug fixes related to electric-powered vehicles

### DIFF
--- a/Source/Vehicles/Components/Vehicles/VehicleDef.cs
+++ b/Source/Vehicles/Components/Vehicles/VehicleDef.cs
@@ -568,10 +568,10 @@ public class VehicleDef : ThingDef, IDefIndex<VehicleDef>, IMaterialCacheTarget,
 
 		if (CompPropsFueledTravel != null)
 		{
-			ThingDef fuelType = CompPropsFueledTravel.fuelType;
+      string fuelLabel = CompPropsFueledTravel.ElectricPowered ? "VF_Electricity".Translate() : CompPropsFueledTravel.fuelType.LabelCap;
 			yield return new VehicleStatDrawEntry(VehicleStatCategoryDefOf.VehicleRefuelable,
 				"VF_FuelType".Translate().CapitalizeFirst(),
-				fuelType.LabelCap, "VF_FuelTypeDesc".Translate(), 4500);
+        fuelLabel, "VF_FuelTypeDesc".Translate(), 4500);
 			float fuelConsumptionRate = vehicle?.CompFueledTravel.FuelEfficiency ??
 				CompPropsFueledTravel.fuelConsumptionRate;
 			yield return new VehicleStatDrawEntry(VehicleStatCategoryDefOf.VehicleRefuelable,

--- a/Source/Vehicles/Comps/FueledTravel/CompFueledTravel.cs
+++ b/Source/Vehicles/Comps/FueledTravel/CompFueledTravel.cs
@@ -129,7 +129,7 @@ public class CompFueledTravel : VehicleComp, IRefundable
 
 	// Electric Vehicles
 	public bool Charging => connectedPower != null && !FullTank &&
-		connectedPower.PowerNet.CurrentStoredEnergy() > Props.chargeRate;
+		connectedPower.PowerNet?.CurrentStoredEnergy() > Props.chargeRate;
 
 	public IEnumerable<(ThingDef thingDef, float count)> Refunds
 	{
@@ -525,6 +525,22 @@ public class CompFueledTravel : VehicleComp, IRefundable
 		if (FuelLeaking)
 			LeakTick();
 
+    if (Props.ElectricPowered)
+    {
+      if (connectedPower is { PowerNet: null })
+        connectedPower = null;
+
+      if (!Charging)
+      {
+        ConsumeFuel(Mathf.Min(DischargeRate * EfficiencyTickMultiplier, Fuel));
+      }
+      else if (Find.TickManager.TicksGame % TicksToCharge == 0)
+      {
+        ChangeStoredEnergy(-ChargeRate);
+        Refuel(ChargeRate);
+      }
+    }
+
 		if (!ShouldConsumeNow)
 			return;
 
@@ -540,19 +556,6 @@ public class CompFueledTravel : VehicleComp, IRefundable
 		if (EmptyTank && !VehicleMod.settings.debug.debugDraftAnyVehicle)
 		{
 			Vehicle.ignition.Drafted = false;
-		}
-
-		if (Props.ElectricPowered)
-		{
-			if (!Charging)
-			{
-				ConsumeFuel(Mathf.Min(DischargeRate * EfficiencyTickMultiplier, Fuel));
-			}
-			else if (Find.TickManager.TicksGame % TicksToCharge == 0)
-			{
-				ChangeStoredEnergy(-ChargeRate);
-				Refuel(ChargeRate);
-			}
 		}
 	}
 

--- a/Source/Vehicles/Gizmo/Gizmo_RefuelableFuelTravel.cs
+++ b/Source/Vehicles/Gizmo/Gizmo_RefuelableFuelTravel.cs
@@ -66,7 +66,8 @@ public class Gizmo_RefuelableFuelTravel : Gizmo_Slider
 
 	protected override string GetTooltip()
 	{
-		return $"{refuelable.TargetFuelLevel:F0} {refuelable.Props.fuelType.LabelCap}";
+    string fuelLabel = refuelable.Props.ElectricPowered ? " Wd" : refuelable.Props.fuelType.LabelCap;
+    return $"{refuelable.TargetFuelLevel:F0} {fuelLabel}";
 	}
 
 	private void UpdateDisableStatus()
@@ -139,7 +140,7 @@ public class Gizmo_RefuelableFuelTravel : Gizmo_Slider
 
 		if (Widgets.ButtonInvisible(iconRect))
 		{
-			ToggleAutoRefuel();
+      ToggleSwitch();
 		}
 
 		if (Mouse.IsOver(iconRect))


### PR DESCRIPTION
I found a few bugs related to electric-powered vehicles.
https://gist.github.com/HugsLibRecordKeeper/8dc833082dfc4f8ffb2677b60ef3b273

1. Charging is not available unless the vehicle is in a state of consuming fuel.
<img width="500" height="300" alt="image" src="https://github.com/user-attachments/assets/12dbec42-53fc-4ad6-aa66-9a1ae236dcf2" />

It won't charge even when connected to power.
--> Changed to perform charging and discharging before the ShouldConsumeNow check.

2. Errors when the parent of a connected power comp despawns.
--> Changed to check whether connectedPower.PowerNet exists within CompTick. And Charging property is referenced outside of the ticks, so I added a null check to PowerNet.

3. Errors in the tooltips and information cards for electric vehicles.
<img width="500" height="300" alt="image" src="https://github.com/user-attachments/assets/86ca235d-ff44-4325-8e64-e630749843d8" />

--> Corrected the fuel label to `Wd` in the gizmo and to `Electricity` in the info card.

4. The charge setting does not toggle when clicking the fuel gizmo icon.
--> Changed ToggleAutoRefuel to ToggleSwitch.