### PR TITLE
Fixed an errror that occurred when attempting to set out on a caravan while out of fuel

### DIFF
--- a/Source/Vehicles/AI/JobGivers/JobGiver_GotoTravelDestinationVehicle.cs
+++ b/Source/Vehicles/AI/JobGivers/JobGiver_GotoTravelDestinationVehicle.cs
@@ -11,7 +11,7 @@ namespace Vehicles;
 public class JobGiver_GotoTravelDestinationVehicle : JobGiver_GotoTravelDestination
 {
   // Amble = Raiders + Vehicle Formations
-  // Walk = 
+  // Walk =
   // Jog = Normal Speed
   // Sprint = Speed Away (escaping raiders?)
 
@@ -31,6 +31,10 @@ public class JobGiver_GotoTravelDestinationVehicle : JobGiver_GotoTravelDestinat
       }
       if (!vehicle.CanReachVehicle(cell, PathEndMode.Touch, PawnUtility.ResolveMaxDanger(pawn, maxDanger),
             TraverseMode(vehicle)))
+      {
+        return null;
+      }
+      if (!vehicle.Drafted)
       {
         return null;
       }

--- a/Source/Vehicles/AI/Lords/Caravan/LordToil_PrepareCaravan_LeaveWithVehicles.cs
+++ b/Source/Vehicles/AI/Lords/Caravan/LordToil_PrepareCaravan_LeaveWithVehicles.cs
@@ -68,6 +68,14 @@ public class LordToil_PrepareCaravan_LeaveWithVehicles : LordToil, IDebugLordMee
   {
     if (Find.TickManager.TicksGame % 100 == 0)
     {
+      foreach (Pawn pawn in lord.ownedPawns)
+      {
+        if (pawn is not VehiclePawn vehicle)
+        {
+          continue;
+        }
+        vehicle.ignition.Drafted = true;
+      }
       ExitMapUtility.CheckArrived(lord, lord.ownedPawns, exitSpot, MemoTrigger.ExitMap,
         CheckPawnArrived, PawnCanMove);
     }


### PR DESCRIPTION
https://gist.github.com/HugsLibRecordKeeper/8b21972432165e2594a6e999c231e82a
I’ve noticed this during testing for a while now, but if I forget to refuel before the caravan leaves, errors occur.
https://github.com/user-attachments/assets/024abf6e-4298-4ca9-a8bf-c959b44b6020

I attempted to fix it in d25852409c93b6a905c67d2b2c990f52df0e4ba9, but I realized that only after a certain amount of time had passed and pawns disembarked would the vehicle be drafted by `UpdateAllDuties` and start moving.
https://github.com/user-attachments/assets/b6b49ee9-74fe-47d2-bfeb-665969c39551

Another issue has arisen, so I'm marking this as a draft for now. I assume a JobGiver must be registered in the duty for the vehicle to be drafted.