### PR TITLE
Replace job instantiation that does not use JobMaker

### DIFF
--- a/Source/Vehicles/AI/JobGivers/JobGiver_AwaitOrders.cs
+++ b/Source/Vehicles/AI/JobGivers/JobGiver_AwaitOrders.cs
@@ -24,11 +24,10 @@ namespace Vehicles
       {
         vehicle.vehiclePather.EngageBrakes();
       }
-      Job job = new(JobDefOf_Vehicles.IdleVehicle, vehicle)
-      {
-        checkOverrideOnExpire = true,
-        expiryInterval = overrideExpiryInterval > 0 ? overrideExpiryInterval : 180
-      };
+
+      Job job = JobMaker.MakeJob(JobDefOf_Vehicles.IdleVehicle, vehicle);
+      job.checkOverrideOnExpire = true;
+      job.expiryInterval = overrideExpiryInterval > 0 ? overrideExpiryInterval : 180;
       return job;
     }
   }

--- a/Source/Vehicles/AI/JobGivers/JobGiver_BoardVehicle.cs
+++ b/Source/Vehicles/AI/JobGivers/JobGiver_BoardVehicle.cs
@@ -32,6 +32,7 @@ public class JobGiver_BoardVehicle : ThinkNode_JobGiver
         job.expiryInterval = 140;
         job.checkOverrideOnExpire = true;
         job.followRadius = FollowRadius;
+        return job;
       }
       return JobMaker.MakeJob(JobDefOf_Vehicles.Board, assignedSeat.Vehicle);
     }

--- a/Source/Vehicles/AI/JobGivers/JobGiver_BoardVehicle.cs
+++ b/Source/Vehicles/AI/JobGivers/JobGiver_BoardVehicle.cs
@@ -27,15 +27,13 @@ public class JobGiver_BoardVehicle : ThinkNode_JobGiver
         if (!JobDriver_FollowClose.FarEnoughAndPossibleToStartJob(pawn, assignedSeat.Vehicle,
           FollowRadius))
           return null;
-        return new Job(JobDefOf.FollowClose, assignedSeat.Vehicle)
-        {
-          lord = pawn.GetLord(),
-          expiryInterval = 140,
-          checkOverrideOnExpire = true,
-          followRadius = FollowRadius
-        };
+        Job job = JobMaker.MakeJob(JobDefOf.FollowClose, assignedSeat.Vehicle);
+        job.lord = pawn.GetLord();
+        job.expiryInterval = 140;
+        job.checkOverrideOnExpire = true;
+        job.followRadius = FollowRadius;
       }
-      return new Job(JobDefOf_Vehicles.Board, assignedSeat.Vehicle);
+      return JobMaker.MakeJob(JobDefOf_Vehicles.Board, assignedSeat.Vehicle);
     }
     return null;
   }

--- a/Source/Vehicles/AI/JobGivers/JobGiver_GotoTravelDestinationVehicle.cs
+++ b/Source/Vehicles/AI/JobGivers/JobGiver_GotoTravelDestinationVehicle.cs
@@ -11,7 +11,7 @@ namespace Vehicles;
 public class JobGiver_GotoTravelDestinationVehicle : JobGiver_GotoTravelDestination
 {
   // Amble = Raiders + Vehicle Formations
-  // Walk = 
+  // Walk =
   // Jog = Normal Speed
   // Sprint = Speed Away (escaping raiders?)
 
@@ -34,11 +34,10 @@ public class JobGiver_GotoTravelDestinationVehicle : JobGiver_GotoTravelDestinat
       {
         return null;
       }
-      Job job = new(JobDefOf.Goto, cell)
-      {
-        locomotionUrgency = LocomotionUrgency.Jog,
-        expiryInterval = jobMaxDuration
-      };
+
+      Job job = JobMaker.MakeJob(JobDefOf.Goto, cell);
+      job.locomotionUrgency = LocomotionUrgency.Jog;
+      job.expiryInterval = jobMaxDuration;
       if (vehicle.InhabitedCellsProjected(cell, Rot8.Invalid)
           .Any(projCell => pawn.Map.exitMapGrid.IsExitCell(projCell)))
       {

--- a/Source/Vehicles/AI/JobGivers/JobGiver_GotoTravelDestinationVehicle.cs
+++ b/Source/Vehicles/AI/JobGivers/JobGiver_GotoTravelDestinationVehicle.cs
@@ -34,7 +34,10 @@ public class JobGiver_GotoTravelDestinationVehicle : JobGiver_GotoTravelDestinat
       {
         return null;
       }
-
+      if (!vehicle.Drafted)
+      {
+        return null;
+      }
       Job job = JobMaker.MakeJob(JobDefOf.Goto, cell);
       job.locomotionUrgency = LocomotionUrgency.Jog;
       job.expiryInterval = jobMaxDuration;

--- a/Source/Vehicles/AI/JobGivers/JobGiver_PrepareVehicleCaravan_GatheringItems.cs
+++ b/Source/Vehicles/AI/JobGivers/JobGiver_PrepareVehicleCaravan_GatheringItems.cs
@@ -22,9 +22,8 @@ public class JobGiver_PrepareVehicleCaravan_GatheringItems : ThinkNode_JobGiver
 		if (thing is null)
 			return null;
 
-		return new Job(JobDef, thing)
-		{
-			lord = lord
-		};
-	}
+    Job job = JobMaker.MakeJob(JobDef, thing);
+    job.lord = lord;
+    return job;
+  }
 }

--- a/Source/Vehicles/AI/JobGivers/JobGiver_SendSlavesToVehicle.cs
+++ b/Source/Vehicles/AI/JobGivers/JobGiver_SendSlavesToVehicle.cs
@@ -18,11 +18,10 @@ namespace Vehicles
 				return null;
 			VehiclePawn vehicle = FindShipToDeposit(pawn, pawn2);
 			VehicleRoleHandler handler = vehicle.handlers.Find(x => x.role.HandlingTypes == HandlingType.None);
-			return new Job(JobDefOf.PrepareCaravan_GatherDownedPawns, pawn2)
-			{
-				count = 1
-			};
-		}
+      Job job = JobMaker.MakeJob(JobDefOf.PrepareCaravan_GatherDownedPawns, pawn2);
+      job.count = 1;
+      return job;
+    }
 
 		private Pawn FindPrisoner(Pawn pawn)
 		{

--- a/Source/Vehicles/AI/JobGivers/NPC/JobGiver_SabotageVehicle.cs
+++ b/Source/Vehicles/AI/JobGivers/NPC/JobGiver_SabotageVehicle.cs
@@ -41,7 +41,7 @@ public class JobGiver_SabotageVehicle : ThinkNode_JobGiver
           IntVec3 jobCell = vehicle.SurroundingCells.RandomOrFallback(cell =>
               resMgr.CanReserve<LocalTargetInfo, VehicleTargetReservation>(vehicle, pawn, cell),
             IntVec3.Invalid);
-          return new Job(JobDefOf_Vehicles.SabotageVehicle, vehicle, jobCell);
+          return JobMaker.MakeJob(JobDefOf_Vehicles.SabotageVehicle, vehicle, jobCell);
         }
       }
     }

--- a/Source/Vehicles/AI/Lords/Caravan/LordToil_PrepareCaravan_LeaveWithVehicles.cs
+++ b/Source/Vehicles/AI/Lords/Caravan/LordToil_PrepareCaravan_LeaveWithVehicles.cs
@@ -68,6 +68,14 @@ public class LordToil_PrepareCaravan_LeaveWithVehicles : LordToil, IDebugLordMee
   {
     if (Find.TickManager.TicksGame % 100 == 0)
     {
+      foreach (Pawn pawn in lord.ownedPawns)
+      {
+        if (pawn is not VehiclePawn vehicle)
+        {
+          continue;
+        }
+        vehicle.ignition.Drafted = true;
+      }
       ExitMapUtility.CheckArrived(lord, lord.ownedPawns, exitSpot, MemoTrigger.ExitMap,
         CheckPawnArrived, PawnCanMove);
     }

--- a/Source/Vehicles/Components/Vehicles/FloatOptionProviders/FloatMenuOptionProvider_OrderVehicle.cs
+++ b/Source/Vehicles/Components/Vehicles/FloatOptionProviders/FloatMenuOptionProvider_OrderVehicle.cs
@@ -119,7 +119,7 @@ public class FloatMenuOptionProvider_OrderVehicle : FloatMenuOptionProvider_Vehi
 
     if (!IsFeatureEnabled(PathFinderV2))
     {
-      Job job = new(JobDefOf.Goto, gotoLoc);
+      Job job = JobMaker.MakeJob(JobDefOf.Goto, gotoLoc);
       vehicle.jobs.TryTakeOrderedJob(job, JobTag.Misc);
       return;
     }

--- a/Source/Vehicles/Components/Vehicles/VehiclePathFollower.cs
+++ b/Source/Vehicles/Components/Vehicles/VehiclePathFollower.cs
@@ -413,10 +413,8 @@ public sealed class VehiclePathFollower : IExposable, IDisposable
       return true;
     }
 
-    Job job = new(JobDefOf.Goto, new LocalTargetInfo(data.destination))
-    {
-      exitMapOnArrival = data.exitMapOnArrival
-    };
+    Job job = JobMaker.MakeJob(JobDefOf.Goto, new LocalTargetInfo(data.destination));
+    job.exitMapOnArrival = data.exitMapOnArrival;
     if (vehicle.jobs.TryTakeOrderedJob(job, JobTag.Misc))
     {
       endRot = data.endRotation;

--- a/Source/Vehicles/Components/Vehicles/VehiclePawn/VehiclePawn_Rendering.cs
+++ b/Source/Vehicles/Components/Vehicles/VehiclePawn/VehiclePawn_Rendering.cs
@@ -991,7 +991,7 @@ public partial class VehiclePawn
       return;
     }
 
-    Job job = new(JobDefOf_Vehicles.Board, this);
+    Job job = JobMaker.MakeJob(JobDefOf_Vehicles.Board, this);
     GiveLoadJob(pawn, handler);
     pawn.jobs.TryTakeOrderedJob(job, JobTag.DraftedOrder);
     if (!pawn.Spawned)

--- a/Source/Vehicles/Comps/FueledTravel/CompFueledTravel.cs
+++ b/Source/Vehicles/Comps/FueledTravel/CompFueledTravel.cs
@@ -483,7 +483,7 @@ public class CompFueledTravel : VehicleComp, IRefundable
     yield return new FloatMenuOption("Refuel".Translate().ToString(),
       delegate
       {
-        Job job = new(JobDefOf_Vehicles.RefuelVehicle, parent, ClosestFuelAvailable(selPawn));
+        Job job = JobMaker.MakeJob(JobDefOf_Vehicles.RefuelVehicle, parent, ClosestFuelAvailable(selPawn));
         selPawn.jobs.TryTakeOrderedJob(job, JobTag.DraftedOrder);
       });
   }

--- a/Source/Vehicles/Comps/Turrets/CompVehicleTurrets.cs
+++ b/Source/Vehicles/Comps/Turrets/CompVehicleTurrets.cs
@@ -175,7 +175,7 @@ public class CompVehicleTurrets : VehicleAIComp, IRefundable
 			{
 				toggleAction = delegate
 				{
-					Vehicle.jobs.StartJob(new Job(JobDefOf_Vehicles.DeployVehicle, targetA: Vehicle),
+					Vehicle.jobs.StartJob(JobMaker.MakeJob(JobDefOf_Vehicles.DeployVehicle, targetA: Vehicle),
 						JobCondition.InterruptForced);
 					deployTicks = DeployTicks;
 				},
@@ -750,7 +750,7 @@ public class CompVehicleTurrets : VehicleAIComp, IRefundable
 
 	private void ResolveAllTurretChildren()
 	{
-		// Break all connections, then reassign. Out of sequence parent and renderer registration can result in child 
+		// Break all connections, then reassign. Out of sequence parent and renderer registration can result in child
 		// turrets being registered as renderers, even though they're drawn by their parents.
 		foreach (VehicleTurret turret in turrets)
 		{
@@ -1077,7 +1077,7 @@ public class CompVehicleTurrets : VehicleAIComp, IRefundable
 	}
 
 	/// <summary>
-	/// Used for serializing turret quotas of turrets that were removed, 
+	/// Used for serializing turret quotas of turrets that were removed,
 	/// such that they will reload the quota if re-added
 	/// </summary>
 	[UsedImplicitly]

--- a/Source/Vehicles/Harmony/Patches/Patch_JobSystem.cs
+++ b/Source/Vehicles/Harmony/Patches/Patch_JobSystem.cs
@@ -84,7 +84,7 @@ internal class Patch_JobSystem : IPatchCategory
           }
           else
           {
-            pawn.jobs.StartJob(new Job(JobDefOf_Vehicles.IdleVehicle, -1),
+            pawn.jobs.StartJob(JobMaker.MakeJob(JobDefOf_Vehicles.IdleVehicle, -1),
               JobCondition.Incompletable);
           }
           startingErrorRecoverJob = false;
@@ -108,7 +108,11 @@ internal class Patch_JobSystem : IPatchCategory
   {
     if (pawn is VehiclePawn)
     {
-      __result = new Job(JobDefOf_Vehicles.IdleVehicle);
+      if (__result is not null)
+      {
+        JobMaker.ReturnToPool(__result);
+      }
+      __result = JobMaker.MakeJob(JobDefOf_Vehicles.IdleVehicle);
       return false;
     }
     return true;


### PR DESCRIPTION
I left CarryPawnToVehicle as-is as the only use case for Job_Vehicle, but it’s possible that this will continue to increase within the job pool?
For the part where the job is being replaced by Harmony, the original job is returned to the pool. No reservation is made, so release is not specifically performed.