### PR TITLE
Fix misplaced vehicle turret icons in UI at non-unit UI scale

### DIFF
--- a/Source/Vehicles/Components/Rendering/Overlays/GraphicOverlay.cs
+++ b/Source/Vehicles/Components/Rendering/Overlays/GraphicOverlay.cs
@@ -306,15 +306,13 @@ public class GraphicOverlay : IAnimationObject, IMaterialCacheTarget,
   IEnumerable<RenderData> IBlitTarget.GetRenderData(Rect rect, BlitRequest request)
   {
     Rect overlayRect = VehicleGraphics.OverlayRect(rect, vehicleDef, this, request.rot);
-    Material material = null;
-    Texture2D texture = Graphic.MatAt(request.rot).mainTexture as Texture2D;
+    Material material = Graphic.MatAt(request.rot);
+    Texture2D texture = material.mainTexture as Texture2D;
     if (Graphic.Shader.SupportsRGBMaskTex())
     {
-      material = Graphic.MatAt(request.rot);
       if (Graphic is Graphic_Rgb graphicRgb)
       {
-        if (Graphic.Shader.SupportsRGBMaskTex())
-          material = RGBMaterialPool.GetUi(this, request.rot);
+        material = RGBMaterialPool.Get(this, request.rot);
         RGBMaterialPool.SetProperties(this, request.patternData, graphicRgb.TexAt, graphicRgb.MaskAt);
       }
       else

--- a/Source/Vehicles/Components/Vehicles/VehicleDef.cs
+++ b/Source/Vehicles/Components/Vehicles/VehicleDef.cs
@@ -716,7 +716,7 @@ public class VehicleDef : ThingDef, IDefIndex<VehicleDef>, IMaterialCacheTarget,
 		Assert.IsNotNull(graphicVehicle);
 
 		Texture2D mainTex = graphicVehicle.TexAt(request.rot);
-		Material material = null;
+		Material material;
 		Shader shader = graphicVehicle.Shader;
 		if (!shader && RGBMaterialPool.TargetCached(this))
 		{
@@ -729,7 +729,11 @@ public class VehicleDef : ThingDef, IDefIndex<VehicleDef>, IMaterialCacheTarget,
 		{
 			RGBMaterialPool.SetProperties(this, request.patternData, graphicVehicle.TexAt,
 				graphicVehicle.MaskAt);
-			material = RGBMaterialPool.GetUi(this, request.rot);
+			material = RGBMaterialPool.Get(this, request.rot);
+		}
+		else
+		{
+			material = graphicVehicle.MatAt(request.rot);
 		}
 		yield return new RenderData(adjustedRect, mainTex, material, PropertyBlock, 0, 0);
 	}

--- a/Source/Vehicles/Turrets/Turret/VehicleTurret_Rendering.cs
+++ b/Source/Vehicles/Turrets/Turret/VehicleTurret_Rendering.cs
@@ -595,9 +595,7 @@ public partial class VehicleTurret
 			BlitRequest request, Graphic_Turret graphic)
 		{
 			bool canMask = graphic.Shader.SupportsRGBMaskTex();
-			Material material = canMask ? graphic.MatAtFull(Rot8.North) : null;
-			if (graphic.Shader.SupportsRGBMaskTex())
-				material = RGBMaterialPool.GetUi(target, request.rot);
+			Material material = canMask ? RGBMaterialPool.Get(target, Rot8.North) : graphic.MatAtFull(Rot8.North);
 			if (canMask && turret.def.matchParentColor)
 			{
 				RGBMaterialPool.SetProperties(target, request.patternData, graphic.TexAt, graphic.MaskAt);

--- a/Source/Vehicles/Utility/Helpers/Rendering/VehicleGUI.cs
+++ b/Source/Vehicles/Utility/Helpers/Rendering/VehicleGUI.cs
@@ -19,8 +19,8 @@ public static class VehicleGui
 	private static readonly List<VehicleTurret> AllTurrets = [];
 	private static readonly List<GraphicOverlay> AllOverlays = [];
 
-	private static (int width, int height) GetOptimalTextureSize(Rect rect, in BlitRequest request,
-		float oversampleFactor)
+	internal static (int width, int height) GetOptimalTextureSize(Rect rect, in BlitRequest request,
+		float oversampleFactor = OversampleFactor)
 	{
 		(int width, int height) max = (0, 0);
 		foreach (IBlitTarget blitTarget in request.blitTargets)
@@ -133,21 +133,38 @@ public static class VehicleGui
 		if (Event.current.type != EventType.Repaint)
 			return;
 
-		TextureDrawer.Open();
 		try
 		{
-			foreach (IBlitTarget blitTarget in request.blitTargets)
+			// Compose the vehicle into a cached RenderTexture (rotation done via GL, never through
+			// GUI.matrix) and draw it flat, which renders correctly at any UIScale.
+			RenderTextureIdler idler =
+				VehicleGuiCache.GetOrBlit(rect, in request, iconScale, forceCentering);
+			if (idler != null && !idler.Disposed)
 			{
-				foreach (RenderData renderData in blitTarget.GetRenderData(rect, request))
-				{
-					TextureDrawer.Add(renderData);
-				}
+				GUI.DrawTexture(rect, idler.Read);
+				return;
 			}
-			TextureDrawer.Draw(rect, scale: iconScale, forceCentering: forceCentering);
+
+			// Fallback to the immediate path if the blit produced no usable texture.
+			TextureDrawer.Open();
+			try
+			{
+				foreach (IBlitTarget blitTarget in request.blitTargets)
+				{
+					foreach (RenderData renderData in blitTarget.GetRenderData(rect, request))
+					{
+						TextureDrawer.Add(renderData);
+					}
+				}
+				TextureDrawer.Draw(rect, scale: iconScale, forceCentering: forceCentering);
+			}
+			finally
+			{
+				TextureDrawer.Close();
+			}
 		}
 		finally
 		{
-			TextureDrawer.Close();
 			AllTurrets.Clear();
 			AllOverlays.Clear();
 		}

--- a/Source/Vehicles/Utility/Helpers/Rendering/VehicleGuiCache.cs
+++ b/Source/Vehicles/Utility/Helpers/Rendering/VehicleGuiCache.cs
@@ -1,0 +1,127 @@
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using CoreLib.Performance;
+using SmashTools;
+using SmashTools.Rendering;
+using UnityEngine;
+
+namespace Vehicles.Rendering;
+
+/// <summary>
+/// Caches the GL-composed RenderTexture for a vehicle UI draw, keyed by everything that affects the
+/// rendered image. A vehicle is blitted once per distinct visual state and the texture is reused until
+/// it idles out, so <see cref="VehicleGui.DrawVehicleOnGUI"/> can draw it flat (un-rotated) every frame.
+/// </summary>
+internal static class VehicleGuiCache
+{
+	private const float IdlerTimeExpiry = 10f; // seconds
+
+	private const float SweepInterval = 5f; // seconds
+
+	private static readonly Dictionary<BlitCacheKey, RenderTextureIdler> Cache = [];
+
+	private static readonly List<BlitCacheKey> SweepBuffer = [];
+
+	private static bool sweepRegistered;
+	private static float sweepTimer;
+
+	/// <summary>
+	/// Returns the idler whose <see cref="RenderTextureIdler.Read"/> holds the composed vehicle, blitting
+	/// on a cache miss. Returns null only when the request resolves to a zero-sized texture.
+	/// </summary>
+	internal static RenderTextureIdler GetOrBlit(Rect rect, in BlitRequest request, float iconScale,
+		bool forceCentering)
+	{
+		EnsureSweep();
+
+		(int width, int height) = VehicleGui.GetOptimalTextureSize(rect, in request);
+		if (width <= 0 || height <= 0)
+			return null;
+
+		BlitCacheKey key = KeyFor(in request, width, height, iconScale, forceCentering);
+		if (Cache.TryGetValue(key, out RenderTextureIdler idler))
+		{
+			if (!idler.Disposed)
+				return idler;
+			Cache.Remove(key);
+		}
+
+		RenderTextureBuffer buffer = VehicleGui.CreateRenderTextureBuffer(rect, in request);
+		idler = new RenderTextureIdler(buffer, IdlerTimeExpiry);
+		VehicleGui.Blit(idler.GetWrite(), rect, in request, iconScale, forceCentering);
+		Cache[key] = idler;
+		return idler;
+	}
+
+	private static BlitCacheKey KeyFor(in BlitRequest request, int width, int height, float iconScale,
+		bool forceCentering)
+	{
+		PatternData pattern = request.patternData;
+
+		// Order-independent signature over the blit targets, so the cache re-blits when turrets or
+		// overlays are added/removed (target identity covers per-vehicle instances).
+		int targetSig = request.blitTargets.Count;
+		foreach (IBlitTarget target in request.blitTargets)
+			targetSig ^= RuntimeHelpers.GetHashCode(target);
+
+		return new BlitCacheKey(
+			request.vehicleDef?.shortHash ?? 0,
+			request.rot,
+			request.iconFrame,
+			pattern?.color ?? Color.white,
+			pattern?.colorTwo ?? Color.white,
+			pattern?.colorThree ?? Color.white,
+			pattern?.tiles ?? 1f,
+			pattern?.displacement ?? Vector2.zero,
+			pattern?.patternDef?.shortHash ?? 0,
+			width,
+			height,
+			iconScale,
+			forceCentering,
+			targetSig);
+	}
+
+	private static void EnsureSweep()
+	{
+		if (sweepRegistered)
+			return;
+		sweepRegistered = true;
+		UnityThread.StartUpdate(Sweep);
+	}
+
+	// Drops cache entries whose idler has freed its textures, bounding growth for keys never revisited.
+	private static bool Sweep()
+	{
+		sweepTimer += Time.deltaTime;
+		if (sweepTimer < SweepInterval)
+			return true;
+		sweepTimer = 0f;
+
+		SweepBuffer.Clear();
+		foreach (KeyValuePair<BlitCacheKey, RenderTextureIdler> entry in Cache)
+		{
+			if (entry.Value.Disposed)
+				SweepBuffer.Add(entry.Key);
+		}
+		foreach (BlitCacheKey key in SweepBuffer)
+			Cache.Remove(key);
+		SweepBuffer.Clear();
+		return true;
+	}
+
+	private readonly record struct BlitCacheKey(
+		int VehicleDef,
+		Rot8 Rot,
+		bool IconFrame,
+		Color Color,
+		Color ColorTwo,
+		Color ColorThree,
+		float Tiles,
+		Vector2 Displacement,
+		int PatternDef,
+		int Width,
+		int Height,
+		float IconScale,
+		bool ForceCentering,
+		int TargetSig);
+}


### PR DESCRIPTION
Fixes #260.

Rotated turret/overlay icons in vehicle UI are misplaced or clipped at non-unit UI scale because they're rotated via `GUI.matrix`, which RimWorld/Unity mis-renders inside GUI groups. Instead of rotating the draw, `DrawVehicleOnGUI` now composes the vehicle (body + rotated turrets/overlays) into a cached `RenderTexture` via `RenderTextureDrawer` and draws it flat — correct at any scale.

- **`VehicleGuiCache`** (new): one composed RT per vehicle visual state (def / rotation / pattern / size / target set), reused until idle; blits via `RenderTextureDrawer`.
- **`DrawVehicleOnGUI`**: routes through the cache and draws the cached RT flat; the immediate path stays as a fallback.

Covers every icon drawn through `DrawVehicleOnGUI` (settings, build menu, caravan, painter, selector, upgrades, cooldown gizmo). All these GUIs have been tested at different scales.

Depends on the [SmashTools fix](https://github.com/SmashPhil/SmashTools/pull/5) that makes `RenderTextureDrawer.Draw` safe to call during `OnGUI`.