### PR TITLE
Set the texture flip flag in the RenderData of VehicleDef and GraphicOverlay

### DIFF
--- a/Source/Vehicles/Components/Rendering/Overlays/GraphicOverlay.cs
+++ b/Source/Vehicles/Components/Rendering/Overlays/GraphicOverlay.cs
@@ -331,10 +331,13 @@ public class GraphicOverlay : IAnimationObject, IMaterialCacheTarget,
         graphic.MatAt(request.rot);
     }
 
+    bool flip = request.rot == Rot8.East && graphic.EastFlipped ||
+                request.rot == Rot8.West && graphic.WestFlipped;
+
     // TODO - vehicleDef.PropertyBlock here would be incorrect for VehiclePawn instance rendering. Will
     // need a refactor later if and when I get to drawing all of this via material property blocks.
     RenderData overlayRenderData = new(overlayRect, texture, material, vehicleDef.PropertyBlock,
-      data.graphicData.DrawOffsetFull(request.rot).y, data.rotation);
+      data.graphicData.DrawOffsetFull(request.rot).y, data.rotation, flip);
     yield return overlayRenderData;
   }
 

--- a/Source/Vehicles/Components/Vehicles/VehicleDef.cs
+++ b/Source/Vehicles/Components/Vehicles/VehicleDef.cs
@@ -743,6 +743,9 @@ public class VehicleDef : ThingDef, IDefIndex<VehicleDef>, IMaterialCacheTarget,
         graphicVehicle.MaskAt);
       material = RGBMaterialPool.GetUi(this, request.rot);
     }
-    yield return new RenderData(adjustedRect, mainTex, material, PropertyBlock, 0, 0);
+
+    bool flip = request.rot == Rot8.East && graphicVehicle.EastFlipped ||
+                request.rot == Rot8.West && graphicVehicle.WestFlipped;
+    yield return new RenderData(adjustedRect, mainTex, material, PropertyBlock, 0, 0, flip);
   }
 }


### PR DESCRIPTION
Fixes #346
After applying the UI offset fixes and flip support, I confirmed that it renders correctly even when facing west, as shown here.
<img width="178" height="173" alt="image" src="https://github.com/user-attachments/assets/4bd39e0c-88ca-4900-b46a-eec6da15a2c7" />