### PR TITLE
fix: make vehicles able to engage and roadkill all hostile pawns including manhunter animals

### DIFF
--- a/Source/Vehicles/Components/Vehicles/VehiclePawn/VehiclePawn_Combat.cs
+++ b/Source/Vehicles/Components/Vehicles/VehiclePawn/VehiclePawn_Combat.cs
@@ -69,7 +69,7 @@ public partial class VehiclePawn
     {
       if (Map.thingGrid.ThingAt(cell, ThingCategory.Pawn) is Pawn pawn and not VehiclePawn)
       {
-        if (pawn.Faction.HostileTo(Faction) || Faction == null ||
+        if (TargetingHelper.IsHostileToVehicleOrFaction(this, pawn) || Faction == null ||
           Rand.Chance(VehicleDamager.FriendlyFireChance(this, pawn)))
         {
           (float pawnDamage, float vehicleDamage) = CalculateImpactDamage(pawn, this, moveSpeed);

--- a/Source/Vehicles/Utility/Helpers/TargetingHelper.cs
+++ b/Source/Vehicles/Utility/Helpers/TargetingHelper.cs
@@ -36,6 +36,11 @@ public static class TargetingHelper
 		return false;
 	}
 
+	internal static bool IsHostileToVehicleOrFaction(VehiclePawn vehicle, Thing target)
+	{
+		return vehicle.HostileTo(target) || target.HostileTo(vehicle.Faction);
+	}
+
 	/// <summary>
 	/// Best attack target for VehicleTurret
 	/// </summary>

--- a/Source/Vehicles/Utility/Helpers/TargetingHelper.cs
+++ b/Source/Vehicles/Utility/Helpers/TargetingHelper.cs
@@ -86,7 +86,7 @@ public static class TargetingHelper
 			{
 				return false;
 			}
-			if (!searcherPawn.HostileTo(thing))
+			if (!IsHostileToVehicleOrFaction(searcherPawn, thing))
 			{
 				return false;
 			}
@@ -167,8 +167,14 @@ public static class TargetingHelper
 			return true;
 		};
 
-		List<IAttackTarget> tmpTargets =
-			[.. searcherPawn.Map.attackTargetsCache.GetPotentialTargetsFor(searcherPawn)];
+		var attackTargetsCache = searcherPawn.Map.attackTargetsCache;
+		HashSet<IAttackTarget> targetSet = [.. attackTargetsCache.GetPotentialTargetsFor(searcherPawn)];
+		if (searcherPawn.Faction != null)
+		{
+			targetSet.UnionWith(attackTargetsCache.TargetsHostileToFaction(searcherPawn.Faction));
+		}
+		List<IAttackTarget> tmpTargets = [.. targetSet];
+
 		bool flag = false;
 		for (int i = 0; i < tmpTargets.Count; i++)
 		{


### PR DESCRIPTION
## Summary

- fixed vehicles not dealing damage when hitting hostile pawns
- fixed vehicles not fighting hostile pawns
specifically, both weren't happening because hostility check wasn't checking `enemy pawn is hostile to vehicle but vice-versa isn't` kind

## Testing

- tested with following modlist: https://rentry.co/m8vizb26
- spawned [M1A2](https://steamcommunity.com/sharedfiles/filedetails/?id=3724793908)
- spawned manhunting animals in debug mode (10000 points, rhinos)

### Before

https://github.com/user-attachments/assets/f051f386-49ca-447f-9c97-3ec15ab519be

- tank does not engage manhunting rhinos
- tank does not deal damage when hitting manhunting rhinos

### After

https://github.com/user-attachments/assets/53cfbba5-8c54-40fb-bca7-61890b0db050

- tank engages manhunting rhinos
- tank deals damage when hitting manhunting rhinos (and kills them)

## Extra

AI usage disclosure: used AI for writing commits (gpt 5.6 sol on pi). Everything else, including testing and opening this PR was done manually.
