### PR TITLE
Fix for the detection of the upgrade button when it overlaps with other upgrade nodes

### DIFF
--- a/Source/Vehicles/Graphics/ITab/ITab_Vehicle_Upgrades.cs
+++ b/Source/Vehicles/Graphics/ITab/ITab_Vehicle_Upgrades.cs
@@ -432,6 +432,7 @@ public class ITab_Vehicle_Upgrades : ITab
   private void DrawUpgradeNodes(Rect rect)
   {
     Rect detailRect = InfoNode != null ? GetDetailRect(rect) : Rect.zero;
+    bool isOverDetail = Mouse.IsOver(detailRect);
     foreach (UpgradeNode upgradeNode in Vehicle.CompUpgradeTree.Props.def.nodes)
     {
       if (upgradeNode.hidden)
@@ -477,7 +478,7 @@ public class ITab_Vehicle_Upgrades : ITab
         }
       }
 
-      if (InfoNode != null && !Mouse.IsOver(detailRect) && Widgets.ButtonInvisible(upgradeRect))
+      if (InfoNode != null && !isOverDetail && Widgets.ButtonInvisible(upgradeRect))
       {
         if (SelectedNode != upgradeNode)
         {


### PR DESCRIPTION
Fixes https://discord.com/channels/588278492655910925/1539455199448662016
Confirmed it works.
<img width="1280" height="720" alt="ITab_Vehicle_Upgrades" src="https://github.com/user-attachments/assets/e831d779-edae-401a-9377-1b30fc503030" />
