### PR TITLE
Fix missing idle vehicle job targets

### DIFF
--- a/Source/Vehicles/Harmony/Patches/Patch_JobSystem.cs
+++ b/Source/Vehicles/Harmony/Patches/Patch_JobSystem.cs
@@ -84,7 +84,7 @@ internal class Patch_JobSystem : IPatchCategory
           }
           else
           {
-            pawn.jobs.StartJob(JobMaker.MakeJob(JobDefOf_Vehicles.IdleVehicle, -1),
+            pawn.jobs.StartJob(JobMaker.MakeJob(JobDefOf_Vehicles.IdleVehicle, pawn),
               JobCondition.Incompletable);
           }
           startingErrorRecoverJob = false;
@@ -112,7 +112,7 @@ internal class Patch_JobSystem : IPatchCategory
       {
         JobMaker.ReturnToPool(__result);
       }
-      __result = JobMaker.MakeJob(JobDefOf_Vehicles.IdleVehicle);
+      __result = JobMaker.MakeJob(JobDefOf_Vehicles.IdleVehicle, pawn);
       return false;
     }
     return true;


### PR DESCRIPTION
## Summary
- Pass the vehicle itself as `TargetA` when creating fallback `IdleVehicle` jobs.
- Fix both the job-error recovery path and the vehicle no-wander fallback.

## Root cause
`JobDriver_IdleVehicle` resolves its vehicle from `TargetA` and immediately applies `FailOnDestroyedOrNull(TargetIndex.A)`. The two fallback construction sites created the job with either an invalid target or no target, causing the job to fail immediately and repeatedly re-enter recovery/job selection. In practice this could produce `started 10 jobs in one tick` spam during vehicle caravan formation.

## Approach
Match the existing normal `JobGiver_AwaitOrders` and combat-formation construction paths by passing the `VehiclePawn` as the job's first target. No recovery or think-tree behavior is otherwise changed.

## Test plan
- [x] Vehicle Framework Release build succeeds with no warnings or errors.
- [x] Vanilla Vehicles Expanded rebuilds against the branch assemblies.
- [x] Natural forming-caravan scenario: after 600 ticks, every observed `IdleVehicle` start retained the exact vehicle as `TargetA`; no 10-jobs-in-one-tick error occurred.
- [x] Error-recovery scenario: one recovery entry produced one `IdleVehicle` job targeting the vehicle, and the same job remained stable across 120 ticks.
- [x] Manual complete-payload deployment smoke-tested.