### PR TITLE
Implement IVehicleWorldObject for StashedVehicle

### DIFF
--- a/Source/Vehicles/World/Shuttle/AerialVehicleInFlight.cs
+++ b/Source/Vehicles/World/Shuttle/AerialVehicleInFlight.cs
@@ -97,10 +97,7 @@ public class AerialVehicleInFlight : DynamicDrawnWorldObject, IVehicleWorldObjec
 	}
 
 	// All pawns will be in the AerialVehicle at all times.
-	public IEnumerable<Pawn> DismountedPawns
-	{
-		get { yield break; }
-	}
+  public IEnumerable<Pawn> DismountedPawns => [];
 
 	public override Material Material
 	{

--- a/Source/Vehicles/World/WorldObjects/StashedVehicle.cs
+++ b/Source/Vehicles/World/WorldObjects/StashedVehicle.cs
@@ -32,9 +32,9 @@ public class StashedVehicle : DynamicDrawnWorldObject, IVehicleWorldObject
 		}
 	}
 
-  public bool CanDismount => false;
+  bool IVehicleWorldObject.CanDismount => false;
 
-  public IEnumerable<Pawn> DismountedPawns => [];
+  IEnumerable<Pawn> IVehicleWorldObject.DismountedPawns => [];
 
 	public override Material Material
 	{

--- a/Source/Vehicles/World/WorldObjects/StashedVehicle.cs
+++ b/Source/Vehicles/World/WorldObjects/StashedVehicle.cs
@@ -11,7 +11,7 @@ using Verse;
 
 namespace Vehicles.World;
 
-public class StashedVehicle : DynamicDrawnWorldObject, IThingHolder
+public class StashedVehicle : DynamicDrawnWorldObject, IVehicleWorldObject
 {
 	private ThingOwner<Thing> stash = [];
 
@@ -31,6 +31,10 @@ public class StashedVehicle : DynamicDrawnWorldObject, IThingHolder
 			}
 		}
 	}
+
+  public bool CanDismount => false;
+
+  public IEnumerable<Pawn> DismountedPawns => [];
 
 	public override Material Material
 	{


### PR DESCRIPTION
To ensure better compatibility with the Vehicle Map Framework, implement `IVehicleWorldObject` in `StashedVehicle`.
Since the changes to VF-393 might cause a conflict, I'll keep this as a draft for now.